### PR TITLE
test: #8 add missing unit tests for AuthController, CourseController,…

### DIFF
--- a/backend/src/main/java/me/klad3/sumapispring/dto/CourseResponse.java
+++ b/backend/src/main/java/me/klad3/sumapispring/dto/CourseResponse.java
@@ -1,10 +1,12 @@
 package me.klad3.sumapispring.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class CourseResponse {

--- a/backend/src/main/java/me/klad3/sumapispring/dto/LoginRequest.java
+++ b/backend/src/main/java/me/klad3/sumapispring/dto/LoginRequest.java
@@ -1,11 +1,13 @@
 package me.klad3.sumapispring.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class LoginRequest {
 
     @NotBlank(message = "Username is mandatory")

--- a/backend/src/test/java/me/klad3/sumapispring/controller/AuthControllerTest.java
+++ b/backend/src/test/java/me/klad3/sumapispring/controller/AuthControllerTest.java
@@ -1,0 +1,148 @@
+package me.klad3.sumapispring.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.klad3.sumapispring.dto.LoginRequest;
+import me.klad3.sumapispring.dto.LoginResponse;
+import me.klad3.sumapispring.exception.AuthenticationException;
+import me.klad3.sumapispring.service.AuthService;
+import me.klad3.sumapispring.service.UserService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void login_ShouldReturnSuccessResponse() throws Exception {
+        LoginRequest loginRequest = LoginRequest.builder()
+                .user("testuser")
+                .password("testpassword")
+                .build();
+
+        LoginResponse loginResponse = LoginResponse.builder()
+                .message("Login successful")
+                .sessionCookies(List.of("SESSIONID=abc123; Path=/; HttpOnly", "CSRF-TOKEN=def456; Path=/; Secure"))
+                .build();
+
+        when(authService.login(any(String.class), any(String.class))).thenReturn(loginResponse);
+
+        mockMvc.perform(post("/user/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.message", is("Login successful")))
+                .andExpect(jsonPath("$.data.message", is("Login successful")))
+                .andExpect(jsonPath("$.data.sessionCookies", hasSize(2)))
+                .andExpect(header().string("Set-Cookie", containsString("SESSIONID=abc123")));
+
+        ArgumentCaptor<String> usernameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> passwordCaptor = ArgumentCaptor.forClass(String.class);
+        verify(authService, times(1)).login(usernameCaptor.capture(), passwordCaptor.capture());
+        assertEquals("testuser", usernameCaptor.getValue());
+        assertEquals("testpassword", passwordCaptor.getValue());
+    }
+
+    @Test
+    void login_WithInvalidInput_ShouldReturnBadRequest() throws Exception {
+        LoginRequest loginRequest = LoginRequest.builder()
+                .user("")
+                .password("")
+                .build();
+
+        mockMvc.perform(post("/user/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.message", is("Validation failed")))
+                .andExpect(jsonPath("$.data.user", is("Username is mandatory")))
+                .andExpect(jsonPath("$.data.password", is("Password is mandatory")));
+
+        verify(authService, never()).login(any(String.class), any(String.class));
+    }
+
+    @Test
+    void login_WithInvalidCredentials_ShouldReturnUnauthorized() throws Exception {
+        LoginRequest loginRequest = LoginRequest.builder()
+                .user("invaliduser")
+                .password("wrongpassword")
+                .build();
+
+        when(authService.login(any(String.class), any(String.class)))
+                .thenThrow(new AuthenticationException("Invalid credentials"));
+
+        mockMvc.perform(post("/user/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.message", is("Authentication Error")))
+                .andExpect(jsonPath("$.data", is(notNullValue())));
+
+        verify(authService, times(1)).login("invaliduser", "wrongpassword");
+    }
+
+    @Test
+    void login_ServiceThrowsException_ShouldReturnInternalServerError() throws Exception {
+        LoginRequest loginRequest = LoginRequest.builder()
+                .user("testuser")
+                .password("testpassword")
+                .build();
+
+        when(authService.login(any(String.class), any(String.class)))
+                .thenThrow(new RuntimeException("Database connection failed"));
+
+        mockMvc.perform(post("/user/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.message", is("Internal Server Error")))
+                .andExpect(jsonPath("$.data.message", is("An unexpected error occurred")))
+                .andExpect(jsonPath("$.data.error", is("Database connection failed")));
+
+        verify(authService, times(1)).login("testuser", "testpassword");
+    }
+}

--- a/backend/src/test/java/me/klad3/sumapispring/controller/CourseControllerTest.java
+++ b/backend/src/test/java/me/klad3/sumapispring/controller/CourseControllerTest.java
@@ -1,0 +1,146 @@
+package me.klad3.sumapispring.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.klad3.sumapispring.dto.CourseResponse;
+import me.klad3.sumapispring.service.CourseService;
+import me.klad3.sumapispring.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(CourseController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class CourseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CourseService courseService;
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private List<CourseResponse> mockCourses;
+
+    @BeforeEach
+    void setUp() {
+        mockCourses = Arrays.asList(
+                CourseResponse.builder()
+                        .carrera("Ingeniería")
+                        .plan("Plan 2023")
+                        .ciclo("Ciclo 1")
+                        .curso("Matemáticas")
+                        .seccion("A")
+                        .profesor("Juan Pérez")
+                        .build(),
+                CourseResponse.builder()
+                        .carrera("Ingeniería")
+                        .plan("Plan 2023")
+                        .ciclo("Ciclo 1")
+                        .curso("Física")
+                        .seccion("B")
+                        .profesor("María García")
+                        .build()
+        );
+    }
+
+    @Test
+    void getCourses_ShouldReturnCourses_WhenCookiesPresent() throws Exception {
+        String cookies = "SESSIONID=abc123; CSRF-TOKEN=def456";
+
+        when(courseService.getCourses(cookies)).thenReturn(mockCourses);
+
+        mockMvc.perform(get("/api/courses")
+                        .header("Cookie", cookies)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.message", is("Courses fetched successfully")))
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].carrera", is("Ingeniería")))
+                .andExpect(jsonPath("$.data[0].plan", is("Plan 2023")))
+                .andExpect(jsonPath("$.data[0].ciclo", is("Ciclo 1")))
+                .andExpect(jsonPath("$.data[0].curso", is("Matemáticas")))
+                .andExpect(jsonPath("$.data[0].seccion", is("A")))
+                .andExpect(jsonPath("$.data[0].profesor", is("Juan Pérez")))
+                .andExpect(jsonPath("$.data[1].carrera", is("Ingeniería")))
+                .andExpect(jsonPath("$.data[1].plan", is("Plan 2023")))
+                .andExpect(jsonPath("$.data[1].ciclo", is("Ciclo 1")))
+                .andExpect(jsonPath("$.data[1].curso", is("Física")))
+                .andExpect(jsonPath("$.data[1].seccion", is("B")))
+                .andExpect(jsonPath("$.data[1].profesor", is("María García")));
+
+        ArgumentCaptor<String> cookiesCaptor = ArgumentCaptor.forClass(String.class);
+        verify(courseService, times(1)).getCourses(cookiesCaptor.capture());
+        assertEquals(cookies, cookiesCaptor.getValue());
+    }
+
+    @Test
+    void getCourses_ShouldReturnUnauthorized_WhenCookiesMissing() throws Exception {
+        mockMvc.perform(get("/api/courses")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.message", is("Missing cookies")))
+                .andExpect(jsonPath("$.data", is(nullValue())));
+
+        verify(courseService, never()).getCourses(anyString());
+    }
+
+    @Test
+    void getCourses_ShouldReturnUnauthorized_WhenCookiesEmpty() throws Exception {
+        mockMvc.perform(get("/api/courses")
+                        .header("Cookie", "")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.message", is("Missing cookies")))
+                .andExpect(jsonPath("$.data", is(nullValue())));
+
+        verify(courseService, never()).getCourses(anyString());
+    }
+
+    @Test
+    void getCourses_ShouldReturnInternalServerError_WhenServiceThrowsException() throws Exception {
+        String cookies = "SESSIONID=abc123; CSRF-TOKEN=def456";
+
+        when(courseService.getCourses(cookies)).thenThrow(new RuntimeException("Database error"));
+
+        mockMvc.perform(get("/api/courses")
+                        .header("Cookie", cookies)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.message", is("Internal Server Error")))
+                .andExpect(jsonPath("$.data.message", is("An unexpected error occurred")))
+                .andExpect(jsonPath("$.data.error", is("Database error")));
+
+        verify(courseService, times(1)).getCourses(cookies);
+    }
+}

--- a/backend/src/test/java/me/klad3/sumapispring/controller/UserControllerTest.java
+++ b/backend/src/test/java/me/klad3/sumapispring/controller/UserControllerTest.java
@@ -1,0 +1,115 @@
+package me.klad3.sumapispring.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.klad3.sumapispring.dto.CreateUserRequest;
+import me.klad3.sumapispring.dto.CreateUserResponse;
+import me.klad3.sumapispring.service.UserService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void createUser_ShouldReturnCreatedResponse() throws Exception {
+        CreateUserRequest createUserRequest = CreateUserRequest.builder()
+                .username("testuser")
+                .email("testuser@example.com")
+                .institutionId("INST123")
+                .studentName("Test User")
+                .build();
+
+        CreateUserResponse createUserResponse = CreateUserResponse.builder()
+                .message("User created successfully")
+                .build();
+
+        when(userService.createUser(any(CreateUserRequest.class))).thenReturn(createUserResponse);
+
+        mockMvc.perform(post("/user/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createUserRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.message", is("User created successfully")))
+                .andExpect(jsonPath("$.data.message", is("User created successfully")));
+
+        verify(userService, times(1)).createUser(any(CreateUserRequest.class));
+    }
+
+    @Test
+    void createUser_WithInvalidEmail_ShouldReturnBadRequest() throws Exception {
+        CreateUserRequest createUserRequest = CreateUserRequest.builder()
+                .username("testuser")
+                .email("invalid-email")
+                .institutionId("INST123")
+                .studentName("Test User")
+                .build();
+
+        mockMvc.perform(post("/user/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createUserRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.message", is("Validation failed")))
+                .andExpect(jsonPath("$.data.email", is("Email should be valid")));
+
+        verify(userService, never()).createUser(any(CreateUserRequest.class));
+    }
+
+    @Test
+    void createUser_ServiceThrowsException_ShouldReturnInternalServerError() throws Exception {
+        CreateUserRequest createUserRequest = CreateUserRequest.builder()
+                .username("testuser")
+                .email("testuser@example.com")
+                .institutionId("INST123")
+                .studentName("Test User")
+                .build();
+
+        when(userService.createUser(any(CreateUserRequest.class)))
+                .thenThrow(new RuntimeException("Database error"));
+
+        mockMvc.perform(post("/user/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createUserRequest)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.message", is("Internal Server Error")))
+                .andExpect(jsonPath("$.data.message", is("An unexpected error occurred")))
+                .andExpect(jsonPath("$.data.error", is("Database error")));
+
+        verify(userService, times(1)).createUser(any(CreateUserRequest.class));
+    }
+}


### PR DESCRIPTION
… and UserController

- Implement tests for AuthController to cover login scenarios: valid login, invalid credentials, empty fields, and service exceptions.
- Add tests for CourseController to cover different cookie states (valid, missing, empty cookies) and error handling.
- Introduce tests for UserController to verify user creation, validation errors (e.g., invalid email), and service exceptions.
- Enhance DTOs (CourseResponse, LoginRequest) with @Builder, @NoArgsConstructor, and @AllArgsConstructor for better testability.
- Ensure code coverage improvements and better error handling coverage for controllers.